### PR TITLE
Refactor to use input variables in tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,20 +2,27 @@
   // See https://go.microsoft.com/fwlink/?LinkId=733558
   // for the documentation about the tasks.json format
   "version": "2.0.0",
+  "inputs": [
+    {
+      "id": "appName",
+      "description": "Which app do you want to run?",
+      "type": "pickString",
+      "options": ["kqac", "wqxr"]
+    }
+  ],
   "tasks": [
-    // WQXR
     {
-      "label": "Pixlet: (WQXR): Serve",
-      "detail": "Start `wqxr.star` in Pixlet",
+      "label": "Pixlet: Serve",
+      "detail": "Start the app in Pixlet",
       "type": "shell",
-      "command": "pixlet serve wqxr/wqxr.star",
+      "command": "pixlet serve ${input:appName}/${input:appName}.star",
       "problemMatcher": []
     },
     {
-      "label": "Pixlet: (WQXR): Format",
-      "detail": "Format `wqxr.star` with Pixlet's built-in formatting",
+      "label": "Pixlet: Format",
+      "detail": "Format with Pixlet's built-in formatting",
       "type": "shell",
-      "command": "pixlet format wqxr/wqxr.star",
+      "command": "pixlet format ${input:appName}/${input:appName}.star",
       "problemMatcher": [],
       "presentation": {
         "reveal": "never",
@@ -24,10 +31,10 @@
       }
     },
     {
-      "label": "Pixlet: (WQXR): Render and push to my Tidbyt",
-      "detail": "Render `wqxr.star` and push it to my Tidbyt",
+      "label": "Pixlet: Render and push to my Tidbyt",
+      "detail": "Render and push it to my Tidbyt",
       "type": "shell",
-      "command": "pixlet render wqxr/wqxr.star && pixlet push --installation-id 'WQXR' promptly-relieved-relaxed-sparrowhawk-d4e wqxr/wqxr.webp",
+      "command": "pixlet render ${input:appName}/${input:appName}.star && pixlet push --installation-id '${input:appName}' promptly-relieved-relaxed-sparrowhawk-d4e ${input:appName}/${input:appName}.webp",
       "problemMatcher": [],
       "presentation": {
         "reveal": "never",
@@ -36,10 +43,10 @@
       }
     },
     {
-      "label": "Pixlet: (WQXR): Generate the preview gif",
-      "detail": "Generate the `wqxr.gif` preview GIF for my README",
+      "label": "Pixlet: Generate the preview gif",
+      "detail": "Generate the preview GIF for my README",
       "type": "shell",
-      "command": "pixlet render wqxr/wqxr.star --gif --magnify 5",
+      "command": "pixlet render ${input:appName}/${input:appName}.star --gif --magnify 5",
       "problemMatcher": [],
       "presentation": {
         "reveal": "never",
@@ -48,62 +55,10 @@
       }
     },
     {
-      "label": "API: (WQXR): Serve mock API",
-      "detail": "Serve fake responses from my local machine for different scenarios from the real WQXR API",
+      "label": "API: Serve mock API",
+      "detail": "Serve fake responses from my local machine for different scenarios from the real API",
       "type": "shell",
-      "command": "python3 -m http.server 61059 --bind 127.0.0.1 --directory wqxr/wqxr-mock-api",
-      "problemMatcher": []
-    },
-
-    // KQAC
-    {
-      "label": "Pixlet: (KQAC): Serve",
-      "detail": "Start `kqac.star` in Pixlet",
-      "type": "shell",
-      "command": "pixlet serve kqac/kqac.star",
-      "problemMatcher": []
-    },
-    {
-      "label": "Pixlet: (KQAC): Format",
-      "detail": "Format `kqac.star` with Pixlet's built-in formatting",
-      "type": "shell",
-      "command": "pixlet format kqac/kqac.star",
-      "problemMatcher": [],
-      "presentation": {
-        "reveal": "never",
-        "revealProblems": "onProblem",
-        "close": true
-      }
-    },
-    {
-      "label": "Pixlet: (KQAC): Render and push to my Tidbyt",
-      "detail": "Render `kqac.star` and push it to my Tidbyt",
-      "type": "shell",
-      "command": "pixlet render kqac/kqac.star && pixlet push --installation-id 'KQAC' promptly-relieved-relaxed-sparrowhawk-d4e kqac/kqac.webp",
-      "problemMatcher": [],
-      "presentation": {
-        "reveal": "never",
-        "revealProblems": "onProblem",
-        "close": true
-      }
-    },
-    {
-      "label": "Pixlet: (KQAC): Generate the preview gif",
-      "detail": "Generate the `kqac.gif` preview GIF for my README",
-      "type": "shell",
-      "command": "pixlet render kqac/kqac.star --gif --magnify 5",
-      "problemMatcher": [],
-      "presentation": {
-        "reveal": "never",
-        "revealProblems": "onProblem",
-        "close": true
-      }
-    },
-    {
-      "label": "API: (KQAC): Serve mock API",
-      "detail": "Serve fake responses from my local machine for different scenarios from the real KQAC API",
-      "type": "shell",
-      "command": "python3 -m http.server 60899 --bind 127.0.0.1 --directory kqac/kqac-mock-api",
+      "command": "python3 -m http.server 61010 --bind 127.0.0.1 --directory ${input:appName}/${input:appName}-mock-api",
       "problemMatcher": []
     }
   ]

--- a/kqac/README.md
+++ b/kqac/README.md
@@ -20,6 +20,6 @@ You can change the following settings:
 
 ## Development
 
-Use VS Code Task **Pixlet: (KQAC): Serve** to get started, then open `http://127.0.0.1:8080` in the browser to see the Pixlet output.
+Use VS Code Task **Pixlet: Serve** and select `kqac` to get started, then open `http://127.0.0.1:8080` in the browser to see the Pixlet output.
 
-I have some mock API responses from KQAC in the [`kqac-mock-api`](kqac-mock-api) folder that can be used with Pixlet by running the **API: (KQAC): Serve mock API** VS Code task and uncommenting the appropriate `NOW_PLAYING` lines in the main [kqac.star](/kqac/kqac.star) file.
+I have some mock API responses from KQAC in the [`kqac-mock-api`](kqac-mock-api) folder that can be used with Pixlet by running the **API: Serve mock API** VS Code task and selecting `kqac`, then uncommenting the appropriate `NOW_PLAYING` lines in the main [kqac.star](/kqac/kqac.star) file.

--- a/kqac/kqac.star
+++ b/kqac/kqac.star
@@ -72,18 +72,18 @@ ERROR_CONTENT = render.Column(
 )
 
 def main(config):
-    # Test data (run the "API: (KQAC): Serve mock API" VS Code task then uncomment a line below to test):
-    # NOW_PLAYING = "http://localhost:60899/between-songs.json" # No catalog item (ex. between songs)
-    # NOW_PLAYING = "http://localhost:60899/specific-show.json" # A particular show without catalog item (ex. NYPhil broadcast)
-    # NOW_PLAYING = "http://localhost:60899/conductor.json" # Regular orchestral work, with conductor (ex. symphony)
-    # NOW_PLAYING = "http://localhost:60899/no-conductor.json" # Regular orchestral work, without conductor (ex. symphony)
-    # NOW_PLAYING = "http://localhost:60899/conductor-and-soloists.json" # Regular orchestral work, with soloists (ex. concerto)
-    # NOW_PLAYING = "http://localhost:60899/no-ensemble-two-soloists.json" # No ensemble name, two soloists (ex. sonata)
-    # NOW_PLAYING = "http://localhost:60899/404.json" # To test "Can't connect" (ex. API is down)
+    # Test data (run the "API: Serve mock API" VS Code task then uncomment a line below to test):
+    # NOW_PLAYING = "http://localhost:61010/between-songs.json" # No catalog item (ex. between songs)
+    # NOW_PLAYING = "http://localhost:61010/specific-show.json" # A particular show without catalog item (ex. NYPhil broadcast)
+    # NOW_PLAYING = "http://localhost:61010/conductor.json" # Regular orchestral work, with conductor (ex. symphony)
+    # NOW_PLAYING = "http://localhost:61010/no-conductor.json" # Regular orchestral work, without conductor (ex. symphony)
+    # NOW_PLAYING = "http://localhost:61010/conductor-and-soloists.json" # Regular orchestral work, with soloists (ex. concerto)
+    # NOW_PLAYING = "http://localhost:61010/no-ensemble-two-soloists.json" # No ensemble name, two soloists (ex. sonata)
+    # NOW_PLAYING = "http://localhost:61010/404.json" # To test "Can't connect" (ex. API is down)
 
     # Unhandled test data
-    # NOW_PLAYING = "http://localhost:60899/no-ensemble-two-soloists.json" # No ensemble name, two soloists (ex. sonata) (they put the second soloist in the "ensemble" line??? This breaks my "Show ensemble" setting)
-    # NOW_PLAYING = "http://localhost:60899/conductor-unreadable-character.json" # Conductor is listed as "Jakub Hrua", but should be "Jakub Hrůša" (this is their fault not mine; not sure how I'd actually address this without better data)
+    # NOW_PLAYING = "http://localhost:61010/no-ensemble-two-soloists.json" # No ensemble name, two soloists (ex. sonata) (they put the second soloist in the "ensemble" line??? This breaks my "Show ensemble" setting)
+    # NOW_PLAYING = "http://localhost:61010/conductor-unreadable-character.json" # Conductor is listed as "Jakub Hrua", but should be "Jakub Hrůša" (this is their fault not mine; not sure how I'd actually address this without better data)
 
     # Get settings values
     scroll_direction = config.str("scroll_direction", DEFAULT_SCROLL_DIRECTION)

--- a/wqxr/README.md
+++ b/wqxr/README.md
@@ -22,6 +22,6 @@ You can change the following settings:
 
 ## Development
 
-Use VS Code Task **Pixlet: (WQXR): Serve** to get started, then open `http://127.0.0.1:8080` in the browser to see the Pixlet output.
+Use VS Code Task **Pixlet: Serve** and select `wqxr` to get started, then open `http://127.0.0.1:8080` in the browser to see the Pixlet output.
 
-I have some mock API responses from WQXR in the [`wqxr-mock-api`](wqxr-mock-api) folder that can be used with Pixlet by running the **API: (WQXR): Serve mock API** VS Code task and uncommenting the appropriate `WHATS_ON` lines in the main [wqxr.star](/wqxr/wqxr.star) file.
+I have some mock API responses from WQXR in the [`wqxr-mock-api`](wqxr-mock-api) folder that can be used with Pixlet by running the **API: Serve mock API** VS Code task and selecting `wqxr`, then uncommenting the appropriate `WHATS_ON` lines in the main [wqxr.star](/wqxr/wqxr.star) file.

--- a/wqxr/wqxr.star
+++ b/wqxr/wqxr.star
@@ -74,19 +74,19 @@ ERROR_CONTENT = render.Column(
 )
 
 def main(config):
-    # Test data (run the "API: (WQXR): Serve mock API" VS Code task then uncomment a line below to test):
-    # WHATS_ON = "http://localhost:61059/between-songs.json" # No catalog item (ex. between songs)
-    # WHATS_ON = "http://localhost:61059/specific-show.json" # A particular show without catalog item (ex. NYPhil broadcast)
-    # WHATS_ON = "http://localhost:61059/conductor.json" # Regular orchestral work, with conductor (ex. symphony)
-    # WHATS_ON = "http://localhost:61059/no-conductor.json" # Regular orchestral work, without conductor (ex. symphony)
-    # WHATS_ON = "http://localhost:61059/conductor-and-soloists.json" # Regular orchestral work, with soloists (ex. concerto)
-    # WHATS_ON = "http://localhost:61059/no-ensemble-two-soloists.json" # No ensemble name, two soloists (ex. sonata)
-    # WHATS_ON = "http://localhost:61059/404.json" # To test "Can't connect" (ex. API is down)
-    # WHATS_ON = "http://localhost:61059/soloist-data-uses-role.json" # Piece has a soloist, but the instrument part is empty (instead it uses "role" for this part)
+    # Test data (run the "API: Serve mock API" VS Code task then uncomment a line below to test):
+    # WHATS_ON = "http://localhost:61010/between-songs.json" # No catalog item (ex. between songs)
+    # WHATS_ON = "http://localhost:61010/specific-show.json" # A particular show without catalog item (ex. NYPhil broadcast)
+    # WHATS_ON = "http://localhost:61010/conductor.json" # Regular orchestral work, with conductor (ex. symphony)
+    # WHATS_ON = "http://localhost:61010/no-conductor.json" # Regular orchestral work, without conductor (ex. symphony)
+    # WHATS_ON = "http://localhost:61010/conductor-and-soloists.json" # Regular orchestral work, with soloists (ex. concerto)
+    # WHATS_ON = "http://localhost:61010/no-ensemble-two-soloists.json" # No ensemble name, two soloists (ex. sonata)
+    # WHATS_ON = "http://localhost:61010/404.json" # To test "Can't connect" (ex. API is down)
+    # WHATS_ON = "http://localhost:61010/soloist-data-uses-role.json" # Piece has a soloist, but the instrument part is empty (instead it uses "role" for this part)
 
     # Unhandled test cases:
-    # WHATS_ON = "http://localhost:61059/long-composer-name.json" # Long composer name (figure out how to handle on vertical mode; it gets cut off) (ex. Mario Castelnuovo-Tedesco in composer)
-    # WHATS_ON = "http://localhost:61059/long-song-title.json" # Long song title (figure out how to handle on vertical mode; it gets cut off) (ex. Fantasy-Septet in song title)
+    # WHATS_ON = "http://localhost:61010/long-composer-name.json" # Long composer name (figure out how to handle on vertical mode; it gets cut off) (ex. Mario Castelnuovo-Tedesco in composer)
+    # WHATS_ON = "http://localhost:61010/long-song-title.json" # Long song title (figure out how to handle on vertical mode; it gets cut off) (ex. Fantasy-Septet in song title)
 
     # Get settings values
     scroll_direction = config.str("scroll_direction", DEFAULT_SCROLL_DIRECTION)


### PR DESCRIPTION
- Change APIs to use the same port (61010) so I don't have to conditionally pick a port based on which API (can't do that with VS Code Tasks anyway)
- Use input variables feature in Tasks (https://code.visualstudio.com/docs/editor/variables-reference#_input-variables)
- Fix READMEs